### PR TITLE
add docker build github workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -14,9 +14,8 @@ jobs:
     steps:
       - name: extract image name and tag using bash parameter expansion
         run: |
-          image_name=${GITHUB_REF_NAME#*/}
-          image_tag=${GITHUB_REF_NAME%%/*}
-          echo "$image_name <> $image_tag"
+          image_name=${GITHUB_REF_NAME%%/*}
+          image_tag=${GITHUB_REF_NAME#*/}
           echo "image_name=$image_name" >> "$GITHUB_ENV"
           echo "image_tag=$image_tag" >> "$GITHUB_ENV"
       - uses: actions/checkout@v3

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,46 @@
+name: Build container image
+
+on:
+  push:
+    tags:
+      - "[a-z-]+:[a-z0-9-]+"
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: extract image name and tag using bash parameter expansion
+        run: |
+          image_name=${GITHUB_REF_NAME#*:}
+          image_tag=${GITHUB_REF_NAME%%:*}
+          echo "image_name=$image_name" >> "$GITHUB_ENV"
+          echo "image_tag=$image_tag" >> "$GITHUB_ENV"
+      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker metadata
+        id: metadata
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ format('ghcr.io/astriaorg/test-images-{0}', env.image_name) }}
+          tags: |
+            type=raw,value=${{env.image_tag}}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          # this gets rid of the unknown/unknown image that is created without this setting
+          # https://github.com/docker/build-push-action/issues/820#issuecomment-1455687416
+          provenance: false
+          context: .
+          file: ${{ format('Dockerfile.{0}', env.image_name) }}
+          platforms: 'linux/amd64,linux/arm64'
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,7 +3,8 @@ name: Build container image
 on:
   push:
     tags:
-      - "[a-z-]+/[a-z0-9-]+"
+      - "[a-z]+/*"
+      - "[a-z]+-[a-z]+/*"
 env:
   REGISTRY: ghcr.io
 
@@ -15,6 +16,7 @@ jobs:
         run: |
           image_name=${GITHUB_REF_NAME#*/}
           image_tag=${GITHUB_REF_NAME%%/*}
+          echo "$image_name <> $image_tag"
           echo "image_name=$image_name" >> "$GITHUB_ENV"
           echo "image_tag=$image_tag" >> "$GITHUB_ENV"
       - uses: actions/checkout@v3

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,7 +3,7 @@ name: Build container image
 on:
   push:
     tags:
-      - "[a-z-]+:[a-z0-9-]+"
+      - "[a-z-]+/[a-z0-9-]+"
 env:
   REGISTRY: ghcr.io
 
@@ -13,8 +13,8 @@ jobs:
     steps:
       - name: extract image name and tag using bash parameter expansion
         run: |
-          image_name=${GITHUB_REF_NAME#*:}
-          image_tag=${GITHUB_REF_NAME%%:*}
+          image_name=${GITHUB_REF_NAME#*/}
+          image_tag=${GITHUB_REF_NAME%%/*}
           echo "image_name=$image_name" >> "$GITHUB_ENV"
           echo "image_tag=$image_tag" >> "$GITHUB_ENV"
       - uses: actions/checkout@v3


### PR DESCRIPTION
This is a simplified github workflow that is only triggered on a tag of the form `<image-name>/<some-version>`. It will attempt to build a `Dockerfile.<image-name>` (for example, `Dockerfile.celestia-node`), and push it to `ghcr.io/astriaorg` under the image name `test-images-celestia-node:<some-version>`.